### PR TITLE
Rework under the hood unmarshalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,31 +50,30 @@ c := np.NewClient(os.Getenv("NOVA_POST_API_KEY"),
 	WithXML,
 	WithJSON, // default
 	np.WithTimeout(5 * time.Second),
+	WithMarshaler(json.Marshal), // default for JSON
+	WithUnmarshaler(xml.Unmarshal), // default for XML
 	np.WithURL("https://api.novaposhta.ua/v2.0/json/"), // set automatically by WithXML, WithJSON
 )
 ```
 
-There's also an option for rawdogging requests, in case something you wish to do is not supported by the library.
+There's also an option for rawdogging requests, in case you wish to do something that is not supported by the library.
 
 ```go
-res, err := c.RawRequest(np.Request{
-	// we don't need to pass an api key, it will be set inside RawRequest method
-	ModelName: "Model",
-	CalledMethod: "method",
-	MethodProperties: map[string]any{
-		"foo": "bar",
-	},
-})
+type customProps struct {
+	Value string `json:"value"`
+}
+
+res, err := c.RawRequest("Model", "method", customProps{Value: "foo"}))
 
 for _, m := range res.Data {
-    fmt.Println(m["foo"]) // res.Data is a slice of maps
+	fmt.Println(m["foo"]) // res.Data is a slice of maps
 }
 ```
 
 ## TODO:
-- Fix tests
-- Fix XML
-- Add constants for common strings, like "Sender" or "ThirdPerson"
+- [ ] Fix tests
+- [ ] Fix XML
+- [ ] Add constants for common strings, like "Sender" or "ThirdPerson"
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ client defaulting to JSON and no timeout.
 
 ```go
 c := np.NewClient(os.Getenv("NOVA_POST_API_KEY"),
-	WithXML,
-	WithJSON, // default
+	np.WithXML,
+	np.WithJSON, // default
 	np.WithTimeout(5 * time.Second),
-	WithMarshaler(json.Marshal), // default for JSON
-	WithUnmarshaler(xml.Unmarshal), // default for XML
+	np.WithMarshaler(json.Marshal), // default for JSON
+	np.WithUnmarshaler(xml.Unmarshal), // default for XML
 	np.WithURL("https://api.novaposhta.ua/v2.0/json/"), // set automatically by WithXML, WithJSON
 )
 ```

--- a/requests.go
+++ b/requests.go
@@ -2,7 +2,7 @@ package novapost
 
 import (
 	"bytes"
-	"net/http"
+	"io"
 )
 
 const (
@@ -23,15 +23,15 @@ func request[Res any](c Client, model, method string, props any) (response Respo
 	if err != nil {
 		return
 	}
-	r, err := http.NewRequest(http.MethodGet, c.url, bytes.NewBuffer(b))
+	res, err := c.http.Post(c.url, "", bytes.NewBuffer(b))
 	if err != nil {
 		return
 	}
-	res, err := c.http.Do(r)
+	b, err = io.ReadAll(res.Body)
 	if err != nil {
 		return
 	}
-	err = c.decoderConstructor(res.Body).Decode(&response)
+	err = c.unmarshaler(b, &response)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This rework changes the way response body is being unmarshalled, no longer creating a Decoder instance, using the standard library's Unmarshal function instead.